### PR TITLE
Doc update about optional dependencies & mappings note

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -50,7 +50,11 @@ project
 
 - themes.lua , terms.lua ( telescope/_extensions dir) and utils.lua (lua dir) 
 
-## Notable mappings
+## Mappings
+
+To see all of the mappings, read the `/lua/chadrc.lua` file, alternatively...
+
+### Some notable mappings are
 ```
 | Key mapping         |  Action  |  Note  |
 |---------------------|--------------------------------------------------------------------| 

--- a/docs/Getting started/Setup.md
+++ b/docs/Getting started/Setup.md
@@ -4,10 +4,15 @@ sidebar_position: 1
 
 ## Pre-requisites 
 
+- [Neovim 0.5](https://neovim.io/)
+- [Use a Nerd Font](https://www.nerdfonts.com/) in your terminal.
 - Terminal supporting true colors ( most already do ).
-- Use a Nerd Font in your terminal.
-- Neovim 0.5
-- ```git``` ``` Node.js```
+- ```git```
+
+#### Semi-optional dependencies
+
+- ```node``` *Node.js* is required for many Language Servers (LSPs)
+- ```ripgrep``` is required for grep searching with *Telescope*
 
 ### Install
 


### PR DESCRIPTION
Hi all,

If users on a clean install, and just follow the current docs, then `<leader> + f + w` for `Telescope live_grep` won't work.

As it has an external, system dependency of `ripgrep`

Added this note and small note in the mappings section too


G